### PR TITLE
画像なし投稿の詳細画面の修正

### DIFF
--- a/templates/mylog/log_detail.html
+++ b/templates/mylog/log_detail.html
@@ -19,7 +19,7 @@
             {% if log.image %}
                 <img src="{{ log.image.url }}" alt="投稿画像" class="bg-w">
             {% else %}
-                <img src="{% static 'img/NoImage.jpg' %}" alt="画像なし" class="bg-w">
+                <img src="{% static 'images/NoImage.jpg' %}" alt="画像なし" class="bg-w">
             {% endif %}
         </div>
         <div class="word bg-w">


### PR DESCRIPTION
# 概要
- 画像なし投稿の詳細画面の修正

# できたこと
- 画像なしの場合の画像の表示

# できていないこと

# その他
- フォルダの名前をかえたことが原因でした